### PR TITLE
Fix last trading day logic

### DIFF
--- a/market_breadth.py
+++ b/market_breadth.py
@@ -443,26 +443,15 @@ def calculate_trend_with_hysteresis(ma_series, threshold=0.001):
     return trend
 
 def get_last_trading_day(date):
-    """
-    Get the last trading day from a given date.
-    If the given date is today, it will return today's date.
-    
-    Args:
-        date (datetime): The date to get the last trading day from
-        
-    Returns:
-        str: The last trading day in YYYY-MM-DD format
-    """
-    today = datetime.today()
-    
-    # If the date is today, return today's date
-    if date.date() == today.date():
-        return date.strftime('%Y-%m-%d')
-    
-    # For past dates, calculate the last trading day
+    """Return the previous trading day for the given date."""
+
+    # Start from the previous day
     last_day = date - timedelta(days=1)
+
+    # Move back to the most recent weekday
     while last_day.weekday() >= 5:  # 5 is Saturday, 6 is Sunday
-        last_day = last_day - timedelta(days=1)
+        last_day -= timedelta(days=1)
+
     return last_day.strftime('%Y-%m-%d')
 
 def get_latest_market_date():

--- a/tests/test_market_breadth_utils.py
+++ b/tests/test_market_breadth_utils.py
@@ -1,0 +1,20 @@
+import unittest
+from datetime import datetime
+
+from market_breadth import get_last_trading_day
+
+class TestGetLastTradingDay(unittest.TestCase):
+    def test_previous_weekday_from_weekday(self):
+        wednesday = datetime(2024, 6, 19)
+        self.assertEqual(get_last_trading_day(wednesday), '2024-06-18')
+
+    def test_previous_weekday_from_monday(self):
+        monday = datetime(2024, 6, 17)
+        self.assertEqual(get_last_trading_day(monday), '2024-06-14')
+
+    def test_previous_weekday_from_weekend(self):
+        sunday = datetime(2024, 6, 16)
+        self.assertEqual(get_last_trading_day(sunday), '2024-06-14')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix `get_last_trading_day` to always return the previous trading day
- add tests for `get_last_trading_day`

## Testing
- `python -m unittest discover -v` *(fails: ModuleNotFoundError: No module named 'requests')*